### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,18 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ inputs:
     default: 'added'
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,8 @@ inputs:
     default: 'added'
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,18 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ alex ${INPUT_ALEX_FLAGS} . 2>&1 >/dev/null \
       -name="alex" \
       -reporter="${INPUT_REPORTER:-github-pr-check}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-level="${INPUT_FAIL_LEVEL}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
+# shellcheck disable=SC2086
 alex ${INPUT_ALEX_FLAGS} . 2>&1 >/dev/null \
   | reviewdog \
       -efm='%-P%f' \


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply it to this actions.