### PR TITLE
fix: propagate exit code for fail_on_error support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 if [ -n "${GITHUB_WORKSPACE}" ] ; then
   git config --global --add safe.directory "${GITHUB_WORKSPACE}" || exit
@@ -8,6 +7,7 @@ fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
+echo '::group:: Running alex with reviewdog 🐶 ...'
 # shellcheck disable=SC2086
 alex ${INPUT_ALEX_FLAGS} . 2>&1 >/dev/null \
   | reviewdog \
@@ -23,3 +23,7 @@ alex ${INPUT_ALEX_FLAGS} . 2>&1 >/dev/null \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS}
+exit_code=$?
+echo '::endgroup::'
+
+exit $exit_code


### PR DESCRIPTION
Hi there! 👋

I noticed this action was listed in reviewdog/reviewdog#949 as needing a fix for the "fail_on_error doesn't cause check to fail" issue.

## What this PR does

This change ensures the action properly propagates reviewdog's exit code, which fixes the behavior where `fail_on_error` or `fail_level` inputs wouldn't actually cause the GitHub Action to fail.

## Changes made

- Removed `set -e` so we can capture the exit code
- Added `exit_code=$?` after the reviewdog command
- Added `exit $exit_code` at the end
- Added GitHub Actions grouping (`::group::`/`::endgroup::`) for cleaner logs

The pattern follows the same fix already applied to other actions like action-golangci-lint#77.

## Testing

I've verified the script syntax is valid. The change is minimal and follows the established pattern from other reviewdog actions.

Please let me know if you'd like any adjustments! Happy to help get this checked off the list in #949 😊

---
Related: reviewdog/reviewdog#949