### PR TITLE
chore: migrate renovate preset to recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "labels": [
     "bump:patch"


### PR DESCRIPTION
## Summary

This is a small Renovate config migration for the open Dependency Dashboard (#60), which currently reports `Config Migration Needed` because the repo still extends the deprecated `config:base` preset.

Change made:
- `config:base` -> `config:recommended`
- kept the existing `bump:patch` label setting unchanged

## Validation

- `python3 -m json.tool .github/renovate.json`

This is intentionally limited to the public Renovate preset migration only; it does not change dependency versions, workflows, credentials, or release settings.
